### PR TITLE
BC BREAK: change how modifyPayload() works

### DIFF
--- a/src/Sqs/Queue.php
+++ b/src/Sqs/Queue.php
@@ -96,7 +96,7 @@ class Queue extends SqsQueue
 
         $body = [
             'job' => $class . '@handle',
-            'data' => isset($body['data']) ? $body['data'] : $body,
+            'data' => $body,
             'uuid' => $payload['MessageId']
         ];
 


### PR DESCRIPTION
this removes the unexpected, confusing behavior where only the `$payload['data']` value would be sent, instead of the entire payload.